### PR TITLE
Default max gas limit

### DIFF
--- a/Aptos/Aptos.Core/Constants.cs
+++ b/Aptos/Aptos.Core/Constants.cs
@@ -4,7 +4,7 @@ namespace Aptos.Core
     {
         public const ulong DEFAULT_TIMEOUT_SECS = 20;
 
-        public const ulong DEFAULT_MAX_GAS_AMOUNT = 200000;
+        public const ulong DEFAULT_MAX_GAS_AMOUNT = 2000000;
 
         public const ulong DEFAULT_TXN_EXP_SEC = 20;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat: Increase default max gas amount by 10x (200000 -> 2000000)
+
 ## 0.0.17-beta
 
 - feat: Add support for Orderless transactions


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description
Increased the `DEFAULT_MAX_GAS_AMOUNT` constant in `Aptos/Aptos.Core/Constants.cs` by 10x, from `200000` to `2000000`. This provides a higher default gas limit for transactions when `MaxGasAmount` is not explicitly specified.

### Test Plan
Verified that the `DEFAULT_MAX_GAS_AMOUNT` constant in `Aptos/Aptos.Core/Constants.cs` is updated to `2000000`.

### Related Links
N/A

---
<p><a href="https://cursor.com/agents/bc-11afdcf9-1564-4ba9-bb2f-20adfe5fea14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11afdcf9-1564-4ba9-bb2f-20adfe5fea14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->