### PR TITLE
Fix: Remove incorrect Uleb128AsU32() call when deserializing Ed25519 public key from JSON

### DIFF
--- a/Aptos.Tests/Aptos.Clients/Aptos.TransactionClient.Tests.cs
+++ b/Aptos.Tests/Aptos.Clients/Aptos.TransactionClient.Tests.cs
@@ -1,0 +1,12 @@
+namespace Aptos.Tests.TransactionClient;
+
+public class AptosTransactionClientTests(ITestOutputHelper output) : BaseTests(output)
+{
+    [Fact(Timeout = 10000)]
+    public async Task GetTransactionByVersion_Ed25519Signature_NoExceptions()
+    {
+        var aptosClient = new AptosClient(new AptosConfig(Networks.Testnet));
+        var txn = await aptosClient.Transaction.GetTransactionByVersion("6694134266");
+        Assert.NotNull(txn);
+    }
+}

--- a/Aptos/Aptos.Crypto/PublicKey.cs
+++ b/Aptos/Aptos.Crypto/PublicKey.cs
@@ -73,9 +73,6 @@ public class PublicKeyConverter : JsonConverter<PublicKey>
         if (anyValue == null)
             throw new Exception("Invalid public key shape");
 
-        Deserializer deserializer = new(anyValue.Value);
-        deserializer.Uleb128AsU32();
-
         return type switch
         {
             "ed25519" => new Ed25519PublicKey(anyValue.Value),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Fixes a bug where deserializing a transaction with an Ed25519 signature would throw `System.ArgumentException: Value is too large to fit in a uint32`.

The `PublicKeyConverter.ReadJson` method was incorrectly calling `Uleb128AsU32()` on the raw public key bytes from the JSON `value` field. In the JSON deserialization context, the `value` field contains raw key bytes (e.g., 32 bytes for Ed25519), not ULEB128-encoded variant + data. For certain byte patterns (like the public key in testnet transaction version 6694134266), the bytes would be misinterpreted as a ULEB128 value exceeding the uint32 range, causing an exception.

The fix removes the unnecessary `Deserializer` creation and `Uleb128AsU32()` call, since the type is already determined from the JSON `type` field. This is consistent with how `PublicKeySignatureConverter.ReadJson` already works (no ULEB128 decoding).

### Test Plan

- Added a regression test `GetTransactionByVersion_Ed25519Signature_NoExceptions` that fetches testnet transaction version 6694134266 (which has an Ed25519 signature that previously triggered the exception).
- All 317 existing tests continue to pass.

### Related Links

- Reproduces with testnet transaction version `6694134266`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3aadaf3-9a2b-44a2-ad46-01d4e91ad206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3aadaf3-9a2b-44a2-ad46-01d4e91ad206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

