### PR TITLE
ci: tag-triggered releases with GitHub Release creation

### DIFF
--- a/.claude/plans/2026-05-21-release-ci.md
+++ b/.claude/plans/2026-05-21-release-ci.md
@@ -1,0 +1,236 @@
+# Release CI Revamp Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the push-to-main release workflow with a tag-triggered one that fixes the NuGet version-check bug and creates a GitHub Release with notes from `CHANGELOG.md`.
+
+**Architecture:** Single file replacement — `.github/workflows/check-and-release.yaml`. Two jobs: `validate` (extracts version, asserts tag matches, guards against re-publishing) and `release` (tests, packs, publishes to NuGet, creates GitHub Release with awk-extracted changelog notes). `run-checks.yaml` is untouched.
+
+**Tech Stack:** GitHub Actions, `dotnet` CLI, `xmllint`, `jq`, `curl`, `awk`, `gh` CLI (pre-installed on `ubuntu-latest`)
+
+---
+
+### Task 1: Replace `check-and-release.yaml`
+
+**Files:**
+- Modify: `.github/workflows/check-and-release.yaml`
+
+- [ ] **Step 1: Create a feature branch**
+
+```bash
+git checkout -b ci/tag-triggered-releases
+```
+
+Expected: switched to new branch `ci/tag-triggered-releases`
+
+- [ ] **Step 2: Verify the fixed NuGet check command works locally**
+
+Run these two commands to confirm `jq contains` gives the right answer before embedding it in CI:
+
+```bash
+# Should output "false" — definitely not published
+PKG_VERSION="99.99.99-beta"
+curl -s "https://api.nuget.org/v3-flatcontainer/aptos/index.json" \
+  | jq -r --arg v "$PKG_VERSION" '.versions | contains([$v])'
+
+# Should output "true" — pick the first version in the list
+PKG_VERSION=$(curl -s "https://api.nuget.org/v3-flatcontainer/aptos/index.json" | jq -r '.versions | first')
+echo "Testing with: $PKG_VERSION"
+curl -s "https://api.nuget.org/v3-flatcontainer/aptos/index.json" \
+  | jq -r --arg v "$PKG_VERSION" '.versions | contains([$v])'
+```
+
+Expected output: `false` then `true`
+
+- [ ] **Step 3: Verify the changelog awk extraction works locally**
+
+```bash
+awk '/^## Unreleased/{found=1; next} found && /^## /{exit} found{print}' CHANGELOG.md
+```
+
+Expected: the text content under `## Unreleased` (breaking changes, features, fixes, security). If output is empty, check that `CHANGELOG.md` has a line starting exactly with `## Unreleased` (no trailing spaces or different casing).
+
+- [ ] **Step 4: Write the new workflow file**
+
+Replace `.github/workflows/check-and-release.yaml` entirely:
+
+```yaml
+name: "Check and Release NuGet Packages"
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate Version and Check NuGet
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      is_published: ${{ steps.nuget_exists.outputs.exists }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet
+
+      - name: Install xmllint
+        run: sudo apt-get install -y libxml2-utils
+        shell: bash
+
+      - name: Extract Version
+        id: version
+        run: |
+          DEFAULT_VERSION=$(xmllint --xpath "string(//*[local-name()='DefaultVersion'])" Directory.Build.props)
+          VERSION_TEMPLATE=$(xmllint --xpath "string(//*[local-name()='PackageVersion'])" Package.props)
+          VERSION=${VERSION_TEMPLATE/'$(DefaultVersion)'/$DEFAULT_VERSION}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Assert tag matches package version
+        env:
+          PKG_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          EXPECTED="v${PKG_VERSION}"
+          ACTUAL="${{ github.ref_name }}"
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "ERROR: tag '${ACTUAL}' does not match expected tag '${EXPECTED}'"
+            exit 1
+          fi
+          echo "Tag matches package version: ${PKG_VERSION}"
+        shell: bash
+
+      - name: Check If NuGet Package Exists
+        id: nuget_exists
+        shell: bash
+        env:
+          PKG_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          EXISTS=$(curl -s "https://api.nuget.org/v3-flatcontainer/aptos/index.json" \
+            | jq -r --arg v "$PKG_VERSION" '.versions | contains([$v])')
+          if [ "$EXISTS" = "true" ]; then
+            echo "Package already published: $PKG_VERSION"
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Package not yet published: $PKG_VERSION"
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+  release:
+    name: Pack and Publish Packages
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: ${{ needs.validate.outputs.is_published == 'false' }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet
+
+      - name: Run Tests
+        run: dotnet test --no-restore --verbosity normal
+        working-directory: ./Aptos.Tests
+        shell: bash
+
+      - name: Pack Packages
+        run: dotnet pack --configuration Release --no-build --output ./artifacts
+        shell: bash
+
+      - name: Publish to NuGet
+        run: |
+          dotnet nuget push ./artifacts/*.nupkg \
+            --source https://api.nuget.org/v3/index.json \
+            --api-key ${{ secrets.NUGET_API_KEY }}
+        shell: bash
+
+      - name: Extract Changelog Notes
+        run: |
+          awk '/^## Unreleased/{found=1; next} found && /^## /{exit} found{print}' \
+            CHANGELOG.md > /tmp/release-notes.md
+          echo "--- Release notes preview ---"
+          cat /tmp/release-notes.md
+        shell: bash
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PKG_VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          gh release create "v${PKG_VERSION}" \
+            --title "v${PKG_VERSION}" \
+            --notes-file /tmp/release-notes.md \
+            ./artifacts/*.nupkg
+        shell: bash
+```
+
+- [ ] **Step 5: Validate YAML syntax**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/check-and-release.yaml'))" && echo "YAML valid"
+```
+
+Expected: `YAML valid`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/check-and-release.yaml
+git commit -m "ci: revamp release workflow — tag trigger, fixed NuGet check, GitHub Release"
+```
+
+---
+
+### Task 2: Validate with actionlint
+
+**Files:**
+- No changes expected (fix any issues actionlint reports)
+
+- [ ] **Step 1: Install actionlint if not present**
+
+```bash
+which actionlint || brew install actionlint
+```
+
+Expected: path to actionlint binary, or a successful brew install
+
+- [ ] **Step 2: Run actionlint on the new workflow**
+
+```bash
+actionlint .github/workflows/check-and-release.yaml
+```
+
+Expected: no output (a clean run produces no output). If there are errors, fix them in the workflow file and re-run until clean.
+
+- [ ] **Step 3: Commit any fixes** (only if actionlint required changes)
+
+```bash
+git add .github/workflows/check-and-release.yaml
+git commit -m "ci: fix actionlint warnings in release workflow"
+```
+
+---
+
+### Developer release instructions (update README or CONTRIBUTING if one exists)
+
+After the CI is merged, a release is performed by:
+
+```bash
+# 1. Bump DefaultVersion in Directory.Build.props, e.g. 0.0.17 → 0.0.18
+# 2. Update ## Unreleased in CHANGELOG.md with notes for this release
+# 3. Merge to main
+# 4. Tag and push (tag must match the full NuGet PackageVersion):
+git tag v0.0.18-beta
+git push origin v0.0.18-beta
+# CI validates, tests, publishes to NuGet, and creates the GitHub Release automatically.
+```

--- a/.claude/specs/2026-05-21-release-ci-design.md
+++ b/.claude/specs/2026-05-21-release-ci-design.md
@@ -1,0 +1,75 @@
+# Release CI Design
+
+**Date:** 2026-05-21
+**Scope:** Revamp `.github/workflows/check-and-release.yaml`
+
+## Goals
+
+1. Switch the release trigger from push-to-main to an explicit git tag push.
+2. Fix the NuGet version-check bug (currently compares against the *latest* published version instead of checking whether the specific version is in the published list).
+3. Add a GitHub Release with release notes extracted from `CHANGELOG.md`.
+
+## Non-Goals
+
+- Changing how the version number is set (still `Directory.Build.props` + `Package.props`).
+- Automating CHANGELOG.md updates.
+- Adding a manual approval gate (GitHub Environment protection rules).
+
+## Trigger
+
+```yaml
+on:
+  push:
+    tags: ['v*']
+```
+
+A release is initiated by pushing a tag whose name equals `v` + the computed `PackageVersion` (e.g., `v0.0.17-beta`). The `run-checks.yaml` workflow continues to handle tests and formatting checks on PRs and main-branch pushes — no changes there.
+
+## Job: `validate`
+
+**Permissions:** `contents: read`
+
+Steps:
+
+1. **Extract version** — use `xmllint` to read `DefaultVersion` from `Directory.Build.props` and `PackageVersion` template from `Package.props`, then substitute to produce the full NuGet version string (e.g., `0.0.17-beta`).
+
+2. **Assert tag matches version** — fail fast if `github.ref_name` != `v${PackageVersion}`. Catches the common mistake of tagging before bumping the version.
+
+3. **NuGet guard (fixed)** — fetch `https://api.nuget.org/v3-flatcontainer/aptos/index.json` and check whether the specific version appears anywhere in `.versions[]`:
+   ```bash
+   jq -r --arg v "$PKG_VERSION" '.versions | contains([$v])'
+   ```
+   If `true`, set `is_published=true` and the `release` job is skipped.
+
+**Outputs:** `version`, `is_published`
+
+## Job: `release`
+
+**Permissions:** `contents: write`
+**Condition:** `needs.validate.outputs.is_published == 'false'`
+
+Steps in order:
+
+1. Checkout + Setup .NET (restore + build).
+2. Run tests — `dotnet test` to verify the tagged commit before publishing.
+3. Pack — `dotnet pack --configuration Release --no-build --output ./artifacts`.
+4. Publish to NuGet — `dotnet nuget push ./artifacts/*.nupkg` using `NUGET_API_KEY` secret.
+5. Extract changelog — `awk` pulls everything under `## Unreleased` down to the next `##` heading in `CHANGELOG.md`.
+6. Create GitHub Release — `gh release create "v${PKG_VERSION}"` against the existing tag, with extracted notes as the body and `.nupkg` files attached as assets.
+
+**Note:** The git-tag creation step present in the current workflow is removed — the tag already exists (it triggered the workflow).
+
+## Secrets Required
+
+| Secret | Purpose |
+|--------|---------|
+| `NUGET_API_KEY` | Publish packages to NuGet (already configured) |
+| `GITHUB_TOKEN` | Create GitHub Release (auto-provided by Actions) |
+
+## Release Workflow (developer steps)
+
+1. Bump `DefaultVersion` in `Directory.Build.props`.
+2. Update `## Unreleased` section in `CHANGELOG.md` with release notes.
+3. Merge to `main`.
+4. Push the tag: `git tag v0.0.18-beta && git push origin v0.0.18-beta`.
+5. CI validates, tests, publishes to NuGet, and creates a GitHub Release automatically.

--- a/.github/workflows/check-and-release.yaml
+++ b/.github/workflows/check-and-release.yaml
@@ -2,15 +2,14 @@ name: "Check and Release NuGet Packages"
 
 on:
   push:
-    branches:
-      - main
+    tags: ['v*']
 
 permissions:
   contents: read
 
 jobs:
-  check:
-    name: Check Packages Version
+  validate:
+    name: Validate Version and Check NuGet
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -27,49 +26,54 @@ jobs:
         uses: ./.github/actions/setup-dotnet
 
       - name: Install xmllint
-        run: sudo apt install -y libxml2-utils
-        working-directory: ./
+        run: sudo apt-get install -y libxml2-utils
         shell: bash
 
-      - name: Extract Version from Directory.Build.props
+      - name: Extract Version
         id: version
         run: |
-          # Extract the default version from Directory.Build.props (e.g., 0.0.5)
           DEFAULT_VERSION=$(xmllint --xpath "string(//*[local-name()='DefaultVersion'])" Directory.Build.props)
-
-          # Extract the template version from Package.props (e.g., "$(DefaultVersion)-beta")
           VERSION_TEMPLATE=$(xmllint --xpath "string(//*[local-name()='PackageVersion'])" Package.props)
-
-          # Replace the template version with the actual version
           VERSION=${VERSION_TEMPLATE/'$(DefaultVersion)'/$DEFAULT_VERSION}
-
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Check If Nuget Package Exists
-        id: nuget_exists
         shell: bash
-        working-directory: ./
+
+      - name: Assert tag matches package version
         env:
           PKG_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          LATEST_VERSION=$(curl -s "https://api.nuget.org/v3-flatcontainer/aptos/index.json" | jq -r '.versions | last')
+          EXPECTED="v${PKG_VERSION}"
+          ACTUAL="${{ github.ref_name }}"
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "ERROR: tag '${ACTUAL}' does not match expected tag '${EXPECTED}'"
+            exit 1
+          fi
+          echo "Tag matches package version: ${PKG_VERSION}"
+        shell: bash
 
-          # Check if the latest version is the same as the current version
-          if [ "$LATEST_VERSION" == "$PKG_VERSION" ]; then
-            echo "Nuget package exists ($PKG_VERSION)"
+      - name: Check If NuGet Package Exists
+        id: nuget_exists
+        shell: bash
+        env:
+          PKG_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          EXISTS=$(curl -s "https://api.nuget.org/v3-flatcontainer/aptos/index.json" \
+            | jq -r --arg v "$PKG_VERSION" '.versions | contains([$v])')
+          if [ "$EXISTS" = "true" ]; then
+            echo "Package already published: $PKG_VERSION"
             echo "exists=true" >> $GITHUB_OUTPUT
           else
-            echo "Nuget package does not exist ($PKG_VERSION)"
+            echo "Package not yet published: $PKG_VERSION"
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
   release:
     name: Pack and Publish Packages
-    needs: check
+    needs: validate
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: ${{ needs.check.outputs.is_published == 'false' }}
+    if: ${{ needs.validate.outputs.is_published == 'false' }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -84,15 +88,30 @@ jobs:
 
       - name: Pack Packages
         run: dotnet pack --configuration Release --no-build --output ./artifacts
+        shell: bash
 
-      - name: Publish Packages to NuGet
+      - name: Publish to NuGet
         run: |
-          dotnet nuget push ./artifacts/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
+          dotnet nuget push ./artifacts/*.nupkg \
+            --source https://api.nuget.org/v3/index.json \
+            --api-key ${{ secrets.NUGET_API_KEY }}
+        shell: bash
 
-      - name: Tag Release
+      - name: Extract Changelog Notes
+        run: |
+          awk '/^## Unreleased/{found=1; next} found && /^## /{exit} found{print}' \
+            CHANGELOG.md > /tmp/release-notes.md
+          echo "--- Release notes preview ---"
+          cat /tmp/release-notes.md
+        shell: bash
+
+      - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PKG_VERSION: ${{ needs.check.outputs.version }}
+          PKG_VERSION: ${{ needs.validate.outputs.version }}
         run: |
-          git tag "v${PKG_VERSION}"
-          git push origin "v${PKG_VERSION}"
+          gh release create "v${PKG_VERSION}" \
+            --title "v${PKG_VERSION}" \
+            --notes-file /tmp/release-notes.md \
+            ./artifacts/*.nupkg
+        shell: bash

--- a/.github/workflows/check-and-release.yaml
+++ b/.github/workflows/check-and-release.yaml
@@ -21,9 +21,12 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet
+        with:
+          build: 'false'
 
       - name: Install xmllint
         run: sudo apt-get install -y libxml2-utils
@@ -50,6 +53,15 @@ jobs:
             exit 1
           fi
           echo "Tag matches package version: ${PKG_VERSION}"
+        shell: bash
+
+      - name: Assert tag is on main branch
+        run: |
+          if ! git merge-base --is-ancestor HEAD origin/main; then
+            echo "ERROR: tagged commit is not on the main branch"
+            exit 1
+          fi
+          echo "Tagged commit is on main branch"
         shell: bash
 
       - name: Check If NuGet Package Exists
@@ -97,7 +109,8 @@ jobs:
         run: |
           dotnet nuget push ./artifacts/*.nupkg \
             --source https://api.nuget.org/v3/index.json \
-            --api-key ${{ secrets.NUGET_API_KEY }}
+            --api-key ${{ secrets.NUGET_API_KEY }} \
+            --skip-duplicate
         shell: bash
 
       - name: Extract Changelog Notes

--- a/.github/workflows/check-and-release.yaml
+++ b/.github/workflows/check-and-release.yaml
@@ -41,11 +41,11 @@ jobs:
       - name: Assert tag matches package version
         env:
           PKG_VERSION: ${{ steps.version.outputs.version }}
+          ACTUAL_TAG: ${{ github.ref_name }}
         run: |
           EXPECTED="v${PKG_VERSION}"
-          ACTUAL="${{ github.ref_name }}"
-          if [ "$ACTUAL" != "$EXPECTED" ]; then
-            echo "ERROR: tag '${ACTUAL}' does not match expected tag '${EXPECTED}'"
+          if [ "$ACTUAL_TAG" != "$EXPECTED" ]; then
+            echo "ERROR: tag '${ACTUAL_TAG}' does not match expected tag '${EXPECTED}'"
             exit 1
           fi
           echo "Tag matches package version: ${PKG_VERSION}"
@@ -77,6 +77,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet

--- a/.github/workflows/check-and-release.yaml
+++ b/.github/workflows/check-and-release.yaml
@@ -34,8 +34,9 @@ jobs:
         run: |
           DEFAULT_VERSION=$(xmllint --xpath "string(//*[local-name()='DefaultVersion'])" Directory.Build.props)
           VERSION_TEMPLATE=$(xmllint --xpath "string(//*[local-name()='PackageVersion'])" Package.props)
-          VERSION=${VERSION_TEMPLATE/'$(DefaultVersion)'/$DEFAULT_VERSION}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          # shellcheck disable=SC2016
+          VERSION=${VERSION_TEMPLATE/'$(DefaultVersion)'/"$DEFAULT_VERSION"}
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Assert tag matches package version
@@ -61,10 +62,10 @@ jobs:
             | jq -r --arg v "$PKG_VERSION" '.versions | contains([$v])')
           if [ "$EXISTS" = "true" ]; then
             echo "Package already published: $PKG_VERSION"
-            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "Package not yet published: $PKG_VERSION"
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
   release:

--- a/.github/workflows/check-and-release.yaml
+++ b/.github/workflows/check-and-release.yaml
@@ -86,7 +86,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: ${{ needs.validate.outputs.is_published == 'false' }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -106,6 +105,7 @@ jobs:
         shell: bash
 
       - name: Publish to NuGet
+        if: ${{ needs.validate.outputs.is_published == 'false' }}
         run: |
           dotnet nuget push ./artifacts/*.nupkg \
             --source https://api.nuget.org/v3/index.json \
@@ -117,11 +117,31 @@ jobs:
         run: |
           awk '/^## Unreleased/{found=1; next} found && /^## /{exit} found{print}' \
             CHANGELOG.md > /tmp/release-notes.md
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "ERROR: release notes are empty — update '## Unreleased' in CHANGELOG.md before tagging"
+            exit 1
+          fi
           echo "--- Release notes preview ---"
           cat /tmp/release-notes.md
         shell: bash
 
+      - name: Check If GitHub Release Exists
+        id: release_exists
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PKG_VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          if gh release view "v${PKG_VERSION}" > /dev/null 2>&1; then
+            echo "GitHub Release already exists: v${PKG_VERSION}"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "GitHub Release does not exist: v${PKG_VERSION}"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+
       - name: Create GitHub Release
+        if: ${{ steps.release_exists.outputs.exists == 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PKG_VERSION: ${{ needs.validate.outputs.version }}


### PR DESCRIPTION
## Summary

- Replaces the push-to-main NuGet release trigger with an explicit `v*` tag push — releases are now intentional, not automatic on every merge
- Fixes a NuGet version-check bug where the old workflow compared against only the *latest* published version (`jq .versions | last`) instead of checking whether the specific version exists anywhere in the list (`jq contains([$v])`)
- Adds a GitHub Release step that extracts the `## Unreleased` section from `CHANGELOG.md` and attaches it (plus `.nupkg` files) to the release

## How to release going forward

```bash
# 1. Bump DefaultVersion in Directory.Build.props
# 2. Update ## Unreleased in CHANGELOG.md
# 3. Merge to main
# 4. Tag and push (tag must match the full NuGet PackageVersion, e.g. v0.0.18-beta):
git tag v0.0.18-beta
git push origin v0.0.18-beta
```

CI will validate the tag matches the version, run tests, publish to NuGet, and create the GitHub Release automatically.

## Test Plan

- [ ] Verify `actionlint .github/workflows/check-and-release.yaml` passes locally
- [ ] Push a test tag matching the current version and confirm the workflow runs end-to-end on GitHub Actions
- [ ] Confirm a GitHub Release is created with correct changelog notes
- [ ] Confirm NuGet package is published at the expected version