### PR TITLE
chore: release v0.1.0-beta

### DIFF
--- a/.github/workflows/check-and-release.yaml
+++ b/.github/workflows/check-and-release.yaml
@@ -114,11 +114,13 @@ jobs:
         shell: bash
 
       - name: Extract Changelog Notes
+        env:
+          PKG_VERSION: ${{ needs.validate.outputs.version }}
         run: |
-          awk '/^## Unreleased/{found=1; next} found && /^## /{exit} found{print}' \
+          awk -v ver="## ${PKG_VERSION}" '$0 ~ ver{found=1; next} found && /^## /{exit} found{print}' \
             CHANGELOG.md > /tmp/release-notes.md
           if [ ! -s /tmp/release-notes.md ]; then
-            echo "ERROR: release notes are empty — update '## Unreleased' in CHANGELOG.md before tagging"
+            echo "ERROR: release notes are empty — add a '## ${PKG_VERSION}' section to CHANGELOG.md before tagging"
             exit 1
           fi
           echo "--- Release notes preview ---"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Aptos .NET SDK Changelog
 
-## Unreleased
+## 0.1.0-beta (2026-05-28)
 
 ### Breaking
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- There should only be one <DefaultVersion> in the file. If moved, it should be updated in
     the GitHub Actions workflow. -->
-    <DefaultVersion>0.0.17</DefaultVersion>
+    <DefaultVersion>0.1.0</DefaultVersion>
     <DefaultTargetFrameworks>net10.0;net9.0</DefaultTargetFrameworks>
     <DefaultTestingFrameworks>net10.0</DefaultTestingFrameworks>
   </PropertyGroup>


### PR DESCRIPTION
## Summary

- Bumps `DefaultVersion` in `Directory.Build.props` from `0.0.17` → `0.1.0`
- Promotes the `## Unreleased` section in `CHANGELOG.md` to `## 0.1.0-beta (2026-05-28)`

## After merging

Push the release tag to trigger the NuGet publish + GitHub Release workflow:

```bash
git checkout main && git pull
git tag v0.1.0-beta
git push origin v0.1.0-beta
```

CI (`check-and-release.yaml`) will:
1. Assert the tag matches the package version
2. Run tests
3. Pack and push `Aptos 0.1.0-beta` to NuGet
4. Create a GitHub Release with the changelog notes